### PR TITLE
Update workflow for Android SDK packages

### DIFF
--- a/.github/workflows/build_apk.yml
+++ b/.github/workflows/build_apk.yml
@@ -15,6 +15,11 @@ jobs:
           java-version: '17'
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3
+        with:
+          packages: |
+            platforms;android-34
+            build-tools;34.0.0
+      - run: echo "sdk.dir=$ANDROID_SDK_ROOT" > local.properties
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build APK


### PR DESCRIPTION
## Summary
- specify Android SDK packages in build_apk workflow
- auto-generate `local.properties` for SDK location

## Testing
- `./gradlew assembleRelease` *(fails: SDK location not found)*
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68546decbbac83278091ce13d563d4f2