### PR TITLE
Fix build by adding GridLayout dependency and adjusting gesture methods

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -36,4 +36,5 @@ dependencies {
     implementation("androidx.core:core-ktx:1.12.0")
     implementation("androidx.appcompat:appcompat:1.7.0")
     implementation("com.google.android.material:material:1.11.0")
+    implementation("androidx.gridlayout:gridlayout:1.0.0")
 }

--- a/app/src/main/java/com/example/a2048/MainActivity.kt
+++ b/app/src/main/java/com/example/a2048/MainActivity.kt
@@ -60,12 +60,12 @@ class MainActivity : AppCompatActivity(), GestureDetector.OnGestureListener {
         }
     }
 
-    override fun onDown(e: MotionEvent?) = true
-    override fun onShowPress(e: MotionEvent?) {}
-    override fun onSingleTapUp(e: MotionEvent?) = false
-    override fun onLongPress(e: MotionEvent?) {}
+    override fun onDown(e: MotionEvent): Boolean = true
+    override fun onShowPress(e: MotionEvent) {}
+    override fun onSingleTapUp(e: MotionEvent): Boolean = false
+    override fun onLongPress(e: MotionEvent) {}
 
-    override fun onScroll(e1: MotionEvent?, e2: MotionEvent?, distanceX: Float, distanceY: Float): Boolean {
+    override fun onScroll(e1: MotionEvent, e2: MotionEvent, distanceX: Float, distanceY: Float): Boolean {
         return false
     }
 


### PR DESCRIPTION
## Summary
- add missing `androidx.gridlayout:gridlayout` dependency
- use non-null parameters to properly implement `GestureDetector.OnGestureListener`

## Testing
- `./gradlew help --warning-mode all`

------
https://chatgpt.com/codex/tasks/task_e_6855c6241bbc8327a8ee925769a300c9